### PR TITLE
chore: clean up files

### DIFF
--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -18,7 +18,7 @@ pub struct Event {
     pub slug: Text,
     pub date: Timestamp,
     pub venue_id: Uuid,
-    pub has_tickets: Boolean
+    pub has_tickets: Boolean,
 }
 
 #[charybdis_view_model(
@@ -34,24 +34,20 @@ pub struct AvailableEvent {
     pub slug: Text,
     pub date: Timestamp,
     pub venue_id: Uuid,
-    pub has_tickets: Boolean
+    pub has_tickets: Boolean,
 }
 
 impl Event {
     pub fn random(venue_id: Uuid) -> Self {
         let generate_event_name = |event_type: &str| {
             let mut rng = rand::thread_rng();
-            let cool_event_names = vec![
-                "The Beatles",
-                "Queen",
-                "The Rolling Stones",
-            ];
+            let cool_event_names = ["The Beatles", "Queen", "The Rolling Stones"];
             let cool_event_name = cool_event_names.choose(&mut rng).unwrap();
 
             format!("{} event {}", cool_event_name, event_type)
         };
 
-        let event_types = vec!["music", "sports", "theater"];
+        let event_types = ["music", "sports", "theater"];
         let event_type = event_types.choose(&mut rand::thread_rng()).unwrap();
 
         let event_name = generate_event_name(event_type);
@@ -64,7 +60,8 @@ impl Event {
             slug: event_slug,
             date: Utc::now(),
             venue_id,
-            has_tickets: true
+            has_tickets: true,
         }
     }
 }
+

--- a/src/models/order.rs
+++ b/src/models/order.rs
@@ -1,7 +1,6 @@
 use charybdis::macros::charybdis_model;
 use charybdis::types::{Decimal, Text, Timestamp, Uuid};
 
-const TTL: &str = "5";
 #[charybdis_model(
     table_name = "orders",
     partition_keys = [order_id],
@@ -35,3 +34,4 @@ pub struct OrderQueue {
     pub session_id: Text,
     pub started_at: Timestamp,
 }
+

--- a/src/models/ticket.rs
+++ b/src/models/ticket.rs
@@ -1,7 +1,5 @@
-use std::str::FromStr;
 use charybdis::macros::{charybdis_model, charybdis_view_model};
 use charybdis::types::{Decimal, Text, Uuid};
-
 
 #[charybdis_model(
     table_name = tickets,
@@ -47,3 +45,4 @@ pub struct AvailableTicket {
     pub price: Decimal,
     pub status: Text,
 }
+


### PR DESCRIPTION
refactor(cdc.rs): reorganize imports and remove unused imports to clean up the file
refactor(cdc.rs): refactor start_cdc_worker function to improve readability and maintainability
refactor(main.rs): reorganize imports and clean up unnecessary imports for better code organization
feat(worker.rs): add handling for unreachable code and add TODO for future query tracking functionality